### PR TITLE
Corrected error with date_time_string implementation

### DIFF
--- a/src/AMEScore.jl
+++ b/src/AMEScore.jl
@@ -1004,7 +1004,7 @@ function leapmacro(param_file::AbstractString,
 				   only_push_leap_results::Bool = false,
 				   run_number_start::Integer = 0,
 				   continue_if_error::Bool = false,
-				   date_time_string::AbstractString = nothing)
+				   date_time_string::Union{Nothing,AbstractString} = nothing)
 
     # Read in global parameters
     params = SUTlib.parse_param_file(param_file, include_energy_sectors = include_energy_sectors, date_time_string = date_time_string)

--- a/src/SUTlib.jl
+++ b/src/SUTlib.jl
@@ -69,7 +69,7 @@ mutable struct TechChangeParams
 end
 
 "Read AMES model configuration file (in YAML syntax). Add or modify entries as needed."
-function parse_param_file(YAML_file::AbstractString; include_energy_sectors::Bool = false, date_time_string::AbstractString = nothing)
+function parse_param_file(YAML_file::AbstractString; include_energy_sectors::Bool = false, date_time_string::Union{Nothing,AbstractString} = nothing)
     global_params = YAML.load_file(YAML_file)
 
     global_params["include-energy-sectors"] = include_energy_sectors


### PR DESCRIPTION
Changed AbstractString to Union{Nothing,AbstractString} to allow for 'nothing' as default parameter.